### PR TITLE
Little workaround to work with pymongo => 3.0

### DIFF
--- a/humbledb/mongo.py
+++ b/humbledb/mongo.py
@@ -111,7 +111,7 @@ class MongoMeta(type):
             to ensure the socket is returned to the connection pool.
         """
         if pyconfig.get('humbledb.allow_explicit_request', True):
-            cls.connection.end_request()
+            pass#cls.connection.end_request()
         try:
             Mongo.contexts.pop()
         except (IndexError, AttributeError):

--- a/humbledb/mongo.py
+++ b/humbledb/mongo.py
@@ -102,7 +102,7 @@ class MongoMeta(type):
             raise NestedConnection("Do not nest a connection within itself, it "
                     "may cause undefined behavior.")
         if pyconfig.get('humbledb.allow_explicit_request', True):
-            cls.connection.start_request()
+            pass#cls.connection.start_request()
         Mongo.contexts.append(cls)
 
     def end(cls):

--- a/humbledb/mongo.py
+++ b/humbledb/mongo.py
@@ -233,6 +233,7 @@ class Mongo(object):
             kwargs.pop('use_greenlets')
         elif _version._gte('3.0.0'):
             kwargs.pop('auto_start_request')
+            kwargs.pop('max_pool_size')
 
         if cls.config_replica:
             kwargs['replicaSet'] = cls.config_replica

--- a/humbledb/mongo.py
+++ b/humbledb/mongo.py
@@ -234,6 +234,7 @@ class Mongo(object):
         elif _version._gte('3.0.0'):
             kwargs.pop('auto_start_request')
             kwargs.pop('max_pool_size')
+            kwargs.pop('use_greenlets')
 
         if cls.config_replica:
             kwargs['replicaSet'] = cls.config_replica

--- a/humbledb/mongo.py
+++ b/humbledb/mongo.py
@@ -231,6 +231,8 @@ class Mongo(object):
             # remove it
             kwargs.pop('auto_start_request')
             kwargs.pop('use_greenlets')
+        elif _version._gte('3.0.0'):
+            kwargs.pop('auto_start_request')
 
         if cls.config_replica:
             kwargs['replicaSet'] = cls.config_replica


### PR DESCRIPTION
Because somethings were deprecated in pymongo the Mongo connection context was broken. I've a little and non-elegant workaround(just removing deprecated params) to be able to use this ODM with pymongo 3.0.2. It's far from definitive solution, but it works.